### PR TITLE
Make sure behavior relations are also "updated" (initialized) upon adding objects.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.1 (2015-03-13)
 ------------------
 
+- Make sure behavior relations are also "updated" (initialized) upon adding objects.
+  [phgross]
+
 - Integrate plone.app.widgets.
   [vangheem]
   

--- a/plone/app/relationfield/configure.zcml
+++ b/plone/app/relationfield/configure.zcml
@@ -39,6 +39,11 @@
            zope.lifecycleevent.interfaces.IObjectModifiedEvent"
       handler=".event.update_behavior_relations"
       />
+    <subscriber
+      for="plone.dexterity.interfaces.IDexterityContent
+           zope.lifecycleevent.interfaces.IObjectAddedEvent"
+      handler=".event.update_behavior_relations"
+      />
     <!-- Make 'related items' behavior available if plone.behavior is present. -->
     <plone:behavior
         zcml:condition="installed plone.behavior"

--- a/plone/app/relationfield/event.py
+++ b/plone/app/relationfield/event.py
@@ -31,7 +31,7 @@ def extract_relations(obj):
 
 
 def update_behavior_relations(obj, event):
-    """Re-register relations in behaviors
+    """Register or re-register relations in behaviors.
     """
     for behavior_interface, name, relation in extract_relations(obj):
         _setRelation(obj, name, relation)

--- a/plone/app/relationfield/testing.py
+++ b/plone/app/relationfield/testing.py
@@ -57,6 +57,7 @@ class PloneAppRelationfieldFixture(PloneSandboxLayer):
     def setUpZope(self, app, configurationContext):
         import plone.app.relationfield
         self.loadZCML(package=plone.app.relationfield)
+        self.loadZCML('tests.zcml', package=plone.app.relationfield)
 
     def setUpPloneSite(self, portal):
         self.applyProfile(portal, 'plone.app.relationfield:default')

--- a/plone/app/relationfield/tests.zcml
+++ b/plone/app/relationfield/tests.zcml
@@ -1,0 +1,16 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:db="http://namespaces.zope.org/db"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    xmlns:plone="http://namespaces.plone.org/plone">
+
+  <plone:behavior
+      title="Relation test behavior."
+      description=""
+      provides=".tests.sample_behavior.ISampleItem"
+      factory="plone.behavior.AnnotationStorage"
+      for="plone.dexterity.interfaces.IDexterityContent"
+      marker=".tests.sample_behavior.ISampleItemMarker"
+      />
+
+</configure>

--- a/plone/app/relationfield/tests/sample_behavior.py
+++ b/plone/app/relationfield/tests/sample_behavior.py
@@ -1,0 +1,32 @@
+from plone.app.dexterity import MessageFactory as _
+from plone.autoform.interfaces import IFormFieldProvider
+from plone.supermodel import model
+from z3c.relationfield.schema import RelationChoice
+from z3c.relationfield.schema import RelationList
+from zope.interface import alsoProvides
+from zope.interface import Interface
+
+
+class ISampleItemMarker(Interface):
+    """Marker Interface
+    """
+
+
+class ISampleItem(model.Schema):
+
+    relations = RelationList(
+        title=_(u'label_related_items', default=u'Related Items'),
+        default=[],
+        value_type=RelationChoice(
+            title=u"Related",
+            vocabulary="plone.app.vocabularies.Catalog"
+        ),
+        required=False
+    )
+
+alsoProvides(ISampleItem, IFormFieldProvider)
+
+
+class ISampleSchema(model.Schema):
+    """Base schema for the sample item.
+    """

--- a/plone/app/relationfield/tests/test_event.py
+++ b/plone/app/relationfield/tests/test_event.py
@@ -1,0 +1,64 @@
+from plone.app.relationfield.testing import FUNCTIONAL_TESTING
+from plone.app.relationfield.tests.sample_behavior import ISampleItem
+from plone.dexterity.fti import DexterityFTI
+from plone.dexterity.fti import register
+from plone.dexterity.utils import addContentToContainer
+from plone.dexterity.utils import createContent
+from plone.dexterity.utils import createContentInContainer
+from Products.CMFCore.utils import getToolByName
+from z3c.relationfield.relation import RelationValue
+from zc.relation.interfaces import ICatalog
+from zope.component import getUtility
+from zope.event import notify
+from zope.intid.interfaces import IIntIds
+from zope.lifecycleevent import ObjectModifiedEvent
+import unittest2 as unittest
+
+
+class TestRelationCatalogUpdater(unittest.TestCase):
+    layer = FUNCTIONAL_TESTING
+
+    def setUp(self):
+        super(TestRelationCatalogUpdater, self).setUp()
+        self.portal = self.layer['portal']
+
+        self.intids = getUtility(IIntIds)
+        self.relation_catalog = getUtility(ICatalog)
+
+        fti = DexterityFTI('SampleItem')
+        fti.klass = 'plone.dexterity.content.Item'
+        fti.behaviors = (
+            'plone.app.relationfield.tests.sample_behavior.ISampleItem', )
+        fti.schema = 'plone.app.relationfield.tests.sample_behavior.ISampleSchema'
+
+        typestool = getToolByName(self.portal, 'portal_types')
+        typestool._setObject('SampleItem', fti)
+        register(fti)
+
+        self.item_a = createContentInContainer(self.portal, 'SampleItem')
+        self.item_c = createContentInContainer(self.portal, 'SampleItem')
+
+        content = createContent('SampleItem')
+        ISampleItem(content).relations = [RelationValue(
+            self.intids.getId(self.item_a))]
+        self.item_b = addContentToContainer(self.portal, content)
+
+    def test_relation_is_added_to_zc_relation_catalog_when_added(self):
+        relations = [rel for rel in self.relation_catalog.findRelations(
+            {'to_id': self.intids.getId(self.item_a)})]
+
+        self.assertEqual(1, len(relations))
+        self.assertEqual(self.intids.getId(self.item_a), relations[0].to_id)
+        self.assertEqual(self.intids.getId(self.item_b), relations[0].from_id)
+
+    def test_relation_is_updated_when_editing(self):
+        ISampleItem(self.item_b).relations = [RelationValue(
+            self.intids.getId(self.item_c))]
+        notify(ObjectModifiedEvent(self.item_b))
+
+        relations = [rel for rel in self.relation_catalog.findRelations(
+            {'to_id': self.intids.getId(self.item_c)})]
+
+        self.assertEqual(1, len(relations))
+        self.assertEqual(self.intids.getId(self.item_c), relations[0].to_id)
+        self.assertEqual(self.intids.getId(self.item_b), relations[0].from_id)


### PR DESCRIPTION
I’ve found a bug in the event handler implementation which updates/adds relations from behavior fields to the zc.relation catalog. The [current implementation](https://github.com/plone/plone.app.relationfield/blob/master/plone/app/relationfield/event.py) works well for adding new relations when editing an object (edit form), but relations wich are set during creation of an Object (AddForm) are not added to zc.relation catalog. This is because the [event subscriber](https://github.com/plone/plone.app.relationfield/blob/e4330a61494dff620ca61c8694dc93b1a69b71c1/plone/app/relationfield/configure.zcml#L37-41) only listens for `IObjectModifiedEvent` but not for `IObjectAddedEvent`.

This PR adds an additional subscriber for the `ObjectAddedEvent`. Unfortunately I wasn’t able to add a corresponding tests, because the test setup is totally broken. If someone could fix the setup or help me to do it, I could amend the PR with a test.

@datakurre @tisto 