### PR TITLE
Support RelatedValues UUID lookup to validate with p.a.vocabularies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,8 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Support RelatedValues UUID lookup to validate with p.a.vocabularies
+  [calvinhp]
 
 Bug fixes:
 

--- a/plone/app/relationfield/adapter.py
+++ b/plone/app/relationfield/adapter.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from Acquisition import aq_base
+from zope.interface import implementer
+from zope.component import adapter
+from plone.uuid.interfaces import IUUID
+from plone.uuid.interfaces import ATTRIBUTE_NAME
+from z3c.relationfield.interfaces import IRelationValue
+
+
+@implementer(IUUID)
+@adapter(IRelationValue)
+def rvUUID(context):
+    """ Vocabulary validation via p.a.vocabularies CatalogSource
+        requires the UUID of the target object to verify membership
+    """
+    return getattr(aq_base(context.to_object), ATTRIBUTE_NAME, None)

--- a/plone/app/relationfield/configure.zcml
+++ b/plone/app/relationfield/configure.zcml
@@ -54,6 +54,9 @@
     <implements interface="z3c.relationfield.interfaces.IHasIncomingRelations" />
   </class>
 
+  <!-- p.a.vocabularies needs UUID support from RelatedValues -->
+  <adapter factory=".adapter.rvUUID" />
+
   <!-- widgets setup -->
   <include file="widget.zcml" />
   <!--<include file="demo.zcml" />-->


### PR DESCRIPTION
CatalogSource needs to validate that the item is in the source via its UUID. When using this relationfield with a custom vocabulary source, it will throw an error when it hits this check. This adapter fixes this issue making the field more generically useful.