### PR TITLE
Related items behavior: show a "recently used" dropdown in the relate…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Related items behavior: show a "recently used" dropdown in the related items widget.
+  The "recently used" dropdown is only available for Mockup 2.6.3+.
+  [thet]
 
 Bug fixes:
 

--- a/plone/app/relationfield/behavior.py
+++ b/plone/app/relationfield/behavior.py
@@ -27,7 +27,10 @@ class IRelatedItems(model.Schema):
     form.widget(
         'relatedItems',
         RelatedItemsFieldWidget,
-        vocabulary='plone.app.vocabularies.Catalog'
+        vocabulary='plone.app.vocabularies.Catalog',
+        pattern_options={
+            'recentlyUsed': True,  # Just turn on. Config in plone.app.widgets.
+        }
     )
 
     fieldset(


### PR DESCRIPTION
…d items widget.

The "recently used" dropdown is only available for Mockup 2.6.3+.