### PR TITLE
Remove installation of plone.app.widgets default profile in tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Remove installation of plone.app.widgets default profile in tests.
+  In Plone 5.0/5.1 with plone.app.widgets >= 2.0, the profile is only a dummy profile for BBB.
+  In Plone 5.2 will be removed.
+  [jensens]
 
 
 1.4.2 (2018-09-28)

--- a/plone/app/relationfield/testing.py
+++ b/plone/app/relationfield/testing.py
@@ -122,7 +122,6 @@ class PloneAppRelationfieldWidgetsFixture(PloneSandboxLayer):
 
     def setUpPloneSite(self, portal):
         self.applyProfile(portal, 'plone.app.dexterity:default')
-        self.applyProfile(portal, 'plone.app.widgets:default')
         self.applyProfile(portal, 'plone.app.relationfield:default')
 
 


### PR DESCRIPTION
In Plone 5.0/5.1 with plone.app.widgets >= 2.0, the profile is only a dummy profile for BBB.
In Plone 5.2 will be removed.