### PR TITLE
chore: p.a.contenttypes is always there [6.0]

### DIFF
--- a/news/4126.bugfix
+++ b/news/4126.bugfix
@@ -1,0 +1,1 @@
+Get rid of no longer needed ``pkg_resources`` usage.  [gforcada]

--- a/plone/app/relationfield/__init__.py
+++ b/plone/app/relationfield/__init__.py
@@ -1,14 +1,4 @@
 from plone.app.relationfield.monkey import PATCHES
 
-import pkg_resources
-
 
 PATCHES
-
-
-try:
-    pkg_resources.get_distribution("plone.app.contenttypes")
-except pkg_resources.DistributionNotFound:
-    HAS_CONTENTTYPES = False
-else:
-    HAS_CONTENTTYPES = True

--- a/plone/app/relationfield/testing.py
+++ b/plone/app/relationfield/testing.py
@@ -1,7 +1,6 @@
 from persistent import Persistent
-from plone.app.relationfield import HAS_CONTENTTYPES
+from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
 from plone.app.testing import FunctionalTesting
-from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
 from z3c.relationfield import RelationList
 from z3c.relationfield.interfaces import IHasRelations
@@ -9,10 +8,6 @@ from zope.interface import implementer
 from zope.interface import Interface
 
 import zope.schema
-
-
-if HAS_CONTENTTYPES:
-    from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
 
 
 class IAddress(Interface):
@@ -47,10 +42,7 @@ class Person(Persistent):
 
 
 class PloneAppRelationfieldFixture(PloneSandboxLayer):
-    if HAS_CONTENTTYPES:
-        defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
-    else:
-        defaultBases = (PLONE_FIXTURE,)
+    defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
         import plone.app.relationfield
@@ -68,10 +60,7 @@ FUNCTIONAL_TESTING = FunctionalTesting(
 
 
 class PloneAppRelationfieldContentTreeFixture(PloneSandboxLayer):
-    if HAS_CONTENTTYPES:
-        defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
-    else:
-        defaultBases = (PLONE_FIXTURE,)
+    defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
         import plone.app.dexterity
@@ -101,10 +90,7 @@ FUNCTIONAL_CONTENTTREE_TESTING = FunctionalTesting(
 
 
 class PloneAppRelationfieldWidgetsFixture(PloneSandboxLayer):
-    if HAS_CONTENTTYPES:
-        defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
-    else:
-        defaultBases = (PLONE_FIXTURE,)
+    defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
 
     def setUpZope(self, app, configurationContext):
         import plone.app.dexterity


### PR DESCRIPTION
back port of PR #62 